### PR TITLE
eslint changes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": [
+    "@workpop/eslint-config-workpop",
+    "plugin:import/errors"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -35,12 +35,6 @@
   "pre-commit": [
     "lint"
   ],
-  "eslintConfig": {
-    "extends": [
-      "@workpop/eslint-config-workpop",
-      "plugin:import/errors"
-    ]
-  },
   "author": "Workpop",
   "license": "ISC"
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "lint"
   ],
   "eslintConfig": {
-    "parser": "babel-eslint",
     "extends": [
       "@workpop/eslint-config-workpop",
       "plugin:import/errors"


### PR DESCRIPTION
* update: dont need to specify parser, already inherited by extending `@workpop/eslint-config-workpop`
* style: prefers `.eslintrc.json` over `eslintConfig` since it can grow large with rule overrides and I'd prefer to have that separate from `package.json`